### PR TITLE
dev・prod のステート分離＋KMS／IAM 修正

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,6 +21,14 @@ terraform plan
 ```
 
 - **prod** 環境を触るときは同じ手順で `envs/prod/backend.conf` と `prod` を指定。
+- prod 環境を使う前に bootstrap を prod で apply して SA / Workload Identity を用意しておく
+
+### ワークスペースと SA の対応関係
+
+```
+dev   → tf-apply-dev
+prod  → tf-apply-prod
+```
 
 ---
 

--- a/terraform/bootstrap/README.md
+++ b/terraform/bootstrap/README.md
@@ -1,5 +1,9 @@
+### KMS とバケット
+
+Cloud Storage バケットを CMEK で暗号化する場合は `service-<PROJECT_NUMBER>@gs-project-accounts.iam.gserviceaccount.com` に `roles/cloudkms.cryptoKeyEncrypterDecrypter` を付与する。
+（dev / prod どちらの bootstrap でも自動付与される実装）
+
 ## TODO
 
 - `${project_id}-data-${env_suffix}` への objectAdmin 付与を import する
   - `terraform/variables.tf` の変数を想定
-- service account key の取り扱いを GitHub Actions OIDC へ移行

--- a/terraform/bootstrap/envs/prod/backend.conf
+++ b/terraform/bootstrap/envs/prod/backend.conf
@@ -1,2 +1,2 @@
-bucket = "terraform-state-portfolio-vertex-ai-dex"
+bucket = "terraform-state-portfolio-vertex-ai-dex-prod"
 prefix = "bootstrap/prod"

--- a/terraform/bootstrap/iam.tf
+++ b/terraform/bootstrap/iam.tf
@@ -1,6 +1,10 @@
+locals {
+  state_bucket_name = var.state_bucket
+}
+
 # ステートバケットの権限付与
 resource "google_storage_bucket_iam_member" "tf_sa_state_bucket" {
-  bucket = google_storage_bucket.tf_state.name
+  bucket = local.state_bucket_name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.tf_apply.email}"
 }
@@ -14,7 +18,7 @@ resource "google_project_iam_member" "tf_sa_viewer" {
 
 # データバケットの bucket-level 権限
 resource "google_storage_bucket_iam_member" "tf_sa_state_bucket_reader" {
-  bucket = google_storage_bucket.tf_state.name
+  bucket = local.state_bucket_name
   role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:${google_service_account.tf_apply.email}"
 }

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -30,7 +30,8 @@ resource "google_storage_bucket" "tf_state" {
   uniform_bucket_level_access = true
 
   depends_on = [
-    google_project_service.services
+    google_project_service.services,
+    google_kms_crypto_key_iam_member.gcs_object_encrypter
   ]
 }
 
@@ -69,4 +70,11 @@ resource "google_kms_crypto_key_iam_member" "terraform_state_encrypter" {
   crypto_key_id = google_kms_crypto_key.terraform_state.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${google_service_account.tf_apply.email}"
+}
+
+# Cloud Storage サービスアカウントに KMS 使用権限を付与
+resource "google_kms_crypto_key_iam_member" "gcs_object_encrypter" {
+  crypto_key_id = google_kms_crypto_key.terraform_state.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${var.project_number}@gs-project-accounts.iam.gserviceaccount.com"
 }

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -5,5 +5,5 @@ output "tf_apply_sa_email" {
 
 output "state_bucket" {
   description = "Terraform state バケット名"
-  value       = google_storage_bucket.tf_state.name
+  value       = var.state_bucket
 }

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -3,6 +3,11 @@ variable "project_id" {
   description = "GCP プロジェクト ID"
 }
 
+variable "project_number" {
+  type        = string
+  description = "GCP プロジェクト番号"
+}
+
 variable "region" {
   type        = string
   description = "リソースを作成するリージョン"

--- a/terraform/envs/dev/backend.conf
+++ b/terraform/envs/dev/backend.conf
@@ -1,3 +1,3 @@
-bucket = "terraform-state-portfolio-vertex-ai-dex"
+bucket = "terraform-state-portfolio-vertex-ai-dex-dev"
 prefix = "vertex-ai/dev"
 # impersonate_service_account = "tf-apply-dev@portfolio-dex-vertex-ai-dev.iam.gserviceaccount.com"

--- a/terraform/envs/prod/backend.conf
+++ b/terraform/envs/prod/backend.conf
@@ -1,2 +1,2 @@
-bucket = "terraform-state-portfolio-vertex-ai-dex"
+bucket = "terraform-state-portfolio-vertex-ai-dex-prod"
 prefix = "vertex-ai/prod"


### PR DESCRIPTION
- dev / prod で GCS バケットを分離
- backend.conf をそれぞれのバケットに合わせて更新
- prefix の食い違いを整理（prod のワークロードは vertex-ai/prod を維持）
- project_number 変数を追加し tfvars で明示
- Cloud Storage サービスアカウントに KMS Encrypter/Decrypter を自動付与
- google_storage_bucket_iam_member の参照をローカル変数化
- outputs.tf をバケット名のローカル値参照に変更
- README 追記