### PR TITLE
Cloud Run Job に削除保護の設定を追加

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -181,6 +181,7 @@ module "fetcher_job_uniswap" {
   secret_name_graph_api = google_secret_manager_secret.api_keys["the-graph-api-key"].secret_id
   service_account       = module.service_accounts.emails["vertex"]
   vpc_connector         = module.network.connector_id
+  deletion_protection   = var.env_suffix == "prod" ? true : false # prod 環境では削除保護
   env_vars = {
     PROJECT_ID                    = local.project_id
     ENV_SUFFIX                    = local.env_suffix
@@ -214,6 +215,7 @@ module "fetcher_job_sushiswap" {
   secret_name_graph_api = google_secret_manager_secret.api_keys["the-graph-api-key"].secret_id
   service_account       = module.service_accounts.emails["vertex"]
   vpc_connector         = module.network.connector_id
+  deletion_protection   = var.env_suffix == "prod" ? true : false # prod 環境では削除保護
   env_vars = {
     PROJECT_ID                      = local.project_id
     ENV_SUFFIX                      = local.env_suffix

--- a/terraform/modules/cloud_run_job/main.tf
+++ b/terraform/modules/cloud_run_job/main.tf
@@ -5,6 +5,8 @@ resource "google_cloud_run_v2_job" "this" {
   location = var.region
   project  = data.google_client_config.this.project
 
+  deletion_protection = var.deletion_protection
+
   template {
     template {
       service_account = var.service_account

--- a/terraform/modules/cloud_run_job/variables.tf
+++ b/terraform/modules/cloud_run_job/variables.tf
@@ -37,3 +37,9 @@ variable "vpc_connector" {
   type        = string
   description = "VPCコネクタの名前"
 }
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Cloud Run Job の削除保護"
+  default     = true
+}


### PR DESCRIPTION
- Cloud Run Job モジュールに削除保護の変数を追加し、プロダクション環境で有効に設定
- 既存の Terraform 設定に削除保護のロジックを組み込み