### PR TITLE
Cloud Run Job の削除保護設定をプロダクション環境に応じて変更

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -181,7 +181,7 @@ module "fetcher_job_uniswap" {
   secret_name_graph_api = google_secret_manager_secret.api_keys["the-graph-api-key"].secret_id
   service_account       = module.service_accounts.emails["vertex"]
   vpc_connector         = module.network.connector_id
-  deletion_protection   = true # 削除保護
+  deletion_protection   = var.env_suffix == "prod" # prod 環境では削除保護
   env_vars = {
     PROJECT_ID                    = local.project_id
     ENV_SUFFIX                    = local.env_suffix
@@ -215,7 +215,7 @@ module "fetcher_job_sushiswap" {
   secret_name_graph_api = google_secret_manager_secret.api_keys["the-graph-api-key"].secret_id
   service_account       = module.service_accounts.emails["vertex"]
   vpc_connector         = module.network.connector_id
-  deletion_protection   = true # 削除保護
+  deletion_protection   = var.env_suffix == "prod" # prod 環境では削除保護
   env_vars = {
     PROJECT_ID                      = local.project_id
     ENV_SUFFIX                      = local.env_suffix


### PR DESCRIPTION
- Cloud Run Jobsの初回デプロイ時の権限エラーにより、環境変数が設定されない不完全な状態でjobが作成されていた問題を修正