### PR TITLE
CI 用 SA の読み取り系ロールを修正

### DIFF
--- a/terraform/bootstrap/iam.tf
+++ b/terraform/bootstrap/iam.tf
@@ -4,6 +4,15 @@ locals {
 
   # CI 用 SA
   ci_sa = "serviceAccount:tf-apply-${var.env_suffix}@${var.project_id}.iam.gserviceaccount.com"
+
+  # 読み取り系ロール
+  viewer_roles = [
+    "roles/viewer",
+    "roles/run.viewer",
+    "roles/aiplatform.viewer",
+    "roles/secretmanager.viewer",
+    "roles/bigquery.metadataViewer",
+  ]
 }
 
 # ステートバケットの権限付与
@@ -15,13 +24,8 @@ resource "google_storage_bucket_iam_member" "tf_sa_state_bucket" {
 
 # CI 用 SA に読み取り系ロールを付与
 resource "google_project_iam_member" "tf_sa_viewer_roles" {
-  for_each = toset([
-    "roles/viewer",               # 汎用 Read
-    "roles/run.viewer",           # Cloud Run
-    "roles/aiplatform.viewer",    # Vertex AI
-    "roles/bigquery.viewer",      # BigQuery
-    "roles/secretmanager.viewer", # Secret Manager
-  ])
+  for_each = toset(local.viewer_roles)
+
   project = var.project_id
   role    = each.value
   member  = local.ci_sa


### PR DESCRIPTION
- Error 400: Role roles/bigquery.viewer is not supported for this resource.の対応