### PR TITLE
Terraform設定ファイルにVertex AI用のバケット権限を追加 (#62)

### DIFF
--- a/terraform/envs/prod/terraform.tfvars
+++ b/terraform/envs/prod/terraform.tfvars
@@ -1,6 +1,6 @@
 env_suffix               = "prod"
 enable_feature_store     = true
 workbench_zone           = "asia-northeast1-a"
-fetcher_image_uri        = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-dev/ml/fetcher@sha256:XXXXXX"
-feature_import_image_uri = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-dev/ml/feature-import@sha256:XXXXXX"
+fetcher_image_uri        = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-prod/ml/fetcher:latest"
+feature_import_image_uri = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-prod/ml/feature-import:latest"
 

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -62,3 +62,10 @@ resource "google_storage_bucket_iam_member" "aiplatform_sa_bucket_reader" {
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:service-${local.project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
 }
+
+# Vertex AI が読み書きするバケット権限
+resource "google_storage_bucket_iam_member" "vertex_raw_bucket_writer" {
+  bucket = google_storage_bucket.data_bucket.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${module.service_accounts.emails["vertex"]}"
+}


### PR DESCRIPTION
* Terraform設定ファイルにVertex AI用のバケット権限を追加

* Terraform設定ファイルのfetcher_image_uriとfeature_import_image_uriをlatestのプロダクションURIに更新