### PR TITLE
 GCS 403 の上書き問題と BigQuery スキーマ不一致を修正

### DIFF
--- a/src/data/fetcher/base.py
+++ b/src/data/fetcher/base.py
@@ -78,7 +78,14 @@ class BaseFetcher:
         out.parent.mkdir(parents=True, exist_ok=True)
         with out.open("w", encoding="utf-8") as f:
             for rec in records:
-                f.write(json.dumps({"raw": rec}, ensure_ascii=False) + "\n")
+                row = {
+                    "raw": rec,
+                    "pool_id": rec["pool"]["id"],
+                    "dex_protocol": f"{self.name}_v3",
+                    "hour_ts": datetime.utcfromtimestamp(rec["periodStartUnix"]).isoformat(timespec="seconds") + "Z",
+                    "load_ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+                }
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
         logging.info(f"[{self.name}] saved {len(records)} to {output_path}")
 
     def run(self, output_path: str, interval_end_iso: str) -> None:

--- a/src/data/fetcher/config.py
+++ b/src/data/fetcher/config.py
@@ -14,7 +14,7 @@ def load_protocol_config() -> ProtocolConfigMap:
     # 環境変数 or YAMLで定義したprotocols.ymlを読み込み
     # config.py は scripts/fetcher/config.py にあるので、
     # 親(parent)[0]=fetcher, 親(parent)[1]=scripts, 親(parent)[2]=project root
-    cfg_path = Path(__file__).resolve().parents[2] / "protocols.yml"
+    cfg_path = Path(__file__).resolve().parents[3] / "protocols.yml"
     if not cfg_path.exists():
         raise FileNotFoundError(f"{cfg_path} が見つかりません")
 


### PR DESCRIPTION
- BaseFetcherクラスのデータ保存処理を更新し、追加情報を含むJSON形式で出力
- config.pyでのプロトコル設定ファイルのパスを修正
- run_fetch_cli.pyでGCSへのアップロード時にユニークIDを追加し、既存ファイルの上書きを防ぐ処理を追加