### PR TITLE
Feature Storeインポートの非同期化とCloud Run推論API追加

### DIFF
--- a/jobs/feature_import/import.sh
+++ b/jobs/feature_import/import.sh
@@ -10,12 +10,58 @@ if ! gsutil -q stat "${GCS_PATH}"; then
   exit 0
 fi
 
-# Feature Store へのインポート
-gcloud ai featurestore entity-types import feature-values \
+# フィールドパスを指定
+FIELD_PATH="stats.entityCount"
+
+# インポート前の行数を記録
+BEFORE_COUNT=$(gcloud ai featurestore entity-types describe dex_liquidity \
+  --featurestore="${FEATURESTORE_ID}" \
+  --region="${REGION}" \
+  --format="value(${FIELD_PATH})" || echo "0")
+
+# Feature Store へのインポート（非同期に変更）
+IMPORT_JOB=$(gcloud ai featurestore entity-types import feature-values \
   --featurestore="${FEATURESTORE_ID}" \
   --entity-type=dex_liquidity \
+  --region="${REGION}" \
   --import-schema-uri=gs://google-cloud-aiplatform/schema/featurestore/import_feature_values_parquet.yaml \
   --gcs-source-uri="${GCS_PATH}" \
   --feature-time-field=feature_timestamp \
   --worker-count=1 \
-  --sync
+  --format="value(name)")
+
+# ジョブの完了を監視（最大30分）
+TIMEOUT=1800
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  STATUS=$(gcloud ai operations describe "${IMPORT_JOB}" --format="value(done)")
+
+  if [ "$STATUS" = "True" ]; then
+    # エラーチェック
+    ERROR=$(gcloud ai operations describe "${IMPORT_JOB}" --format="value(error.message)")
+    if [ -n "$ERROR" ]; then
+      echo "Import failed: $ERROR" >&2
+      exit 1
+    fi
+    break
+  fi
+  sleep 30
+  ELAPSED=$((ELAPSED + 30))
+done
+
+# タイムアウトチェック
+if [ $ELAPSED -ge $TIMEOUT ]; then
+  echo "Import timeout after ${TIMEOUT} seconds" >&2
+  exit 1
+fi
+
+# entityCountの遅延を考慮して少し待つ
+sleep 10
+
+# インポート後の検証
+AFTER_COUNT=$(gcloud ai featurestore entity-types describe dex_liquidity \
+  --featurestore="${FEATURESTORE_ID}" \
+  --region="${REGION}" \
+  --format="value(${FIELD_PATH})" || echo "0")
+
+echo "Import complete: before=$BEFORE_COUNT, after=$AFTER_COUNT"

--- a/terraform/envs/dev/terraform.tfvars
+++ b/terraform/envs/dev/terraform.tfvars
@@ -3,3 +3,4 @@ enable_feature_store     = true
 workbench_zone           = "asia-northeast1-a"
 fetcher_image_uri        = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-dev/ml/fetcher:latest"
 feature_import_image_uri = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-dev/ml/feature-import:latest"
+prediction_image_uri     = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-dev/ml/prediction-api:latest"

--- a/terraform/envs/prod/terraform.tfvars
+++ b/terraform/envs/prod/terraform.tfvars
@@ -3,4 +3,4 @@ enable_feature_store     = true
 workbench_zone           = "asia-northeast1-a"
 fetcher_image_uri        = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-prod/ml/fetcher:latest"
 feature_import_image_uri = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-prod/ml/feature-import:latest"
-
+prediction_image_uri     = "asia-northeast1-docker.pkg.dev/portfolio-dex-vertex-ai-prod/ml/prediction-api:latest"

--- a/terraform/feature_import.tf
+++ b/terraform/feature_import.tf
@@ -7,6 +7,7 @@ module "feature_import_job" {
   project_id = local.project_id
   name       = "fs-import-${local.env_suffix}"
   region     = local.region
+  env_suffix = local.env_suffix
 
   image_uri       = var.feature_import_image_uri
   service_account = module.service_accounts.emails["vertex-pipeline"]

--- a/terraform/modules/cloud_run_job/main.tf
+++ b/terraform/modules/cloud_run_job/main.tf
@@ -31,6 +31,11 @@ resource "google_cloud_run_v2_job" "this" {
           value = var.project_id
         }
 
+        env {
+          name  = "ENV_SUFFIX"
+          value = var.env_suffix
+        }
+
         # Secret 参照 env
         dynamic "env" {
           # シークレットがない場合は空オブジェクト
@@ -50,7 +55,7 @@ resource "google_cloud_run_v2_job" "this" {
       }
       vpc_access { connector = var.vpc_connector }
       max_retries           = 3
-      timeout               = "600s"
+      timeout               = var.env_suffix == "prod" ? "900s" : "600s" # 環境によってタイムアウトを調整
       execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
     }
   }

--- a/terraform/modules/cloud_run_job/variables.tf
+++ b/terraform/modules/cloud_run_job/variables.tf
@@ -3,6 +3,12 @@ variable "project_id" {
   description = "GCP プロジェクト ID"
 }
 
+variable "env_suffix" {
+  description = "環境識別子（dev/prod）"
+  type        = string
+  default     = "dev"
+}
+
 variable "name" {
   type        = string
   description = "Cloud Run Job の名前"

--- a/terraform/modules/cloud_run_service/main.tf
+++ b/terraform/modules/cloud_run_service/main.tf
@@ -1,0 +1,75 @@
+
+resource "google_cloud_run_v2_service" "this" {
+  name     = var.name
+  location = var.region
+
+  template {
+    scaling {
+      min_instance_count = var.env_suffix == "prod" ? max(var.min_instances, 1) : var.min_instances
+      max_instance_count = var.max_instances
+    }
+
+    service_account = var.service_account
+
+    # VPC Connectorの条件付き設定
+    dynamic "vpc_access" {
+      for_each = var.vpc_connector != null ? [1] : []
+      content {
+        connector = var.vpc_connector
+      }
+    }
+
+    containers {
+      image = var.image_uri
+
+      resources {
+        limits = {
+          cpu    = var.cpu_limit
+          memory = var.memory_limit
+        }
+      }
+
+      # ヘルスチェック
+      startup_probe {
+        http_get {
+          path = "/health"
+        }
+        initial_delay_seconds = 10
+        period_seconds        = 10
+        failure_threshold     = 3
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+        }
+        initial_delay_seconds = 30
+        period_seconds        = 30
+        failure_threshold     = 3
+      }
+
+      dynamic "env" {
+        for_each = var.env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+    }
+  }
+
+  # トラフィック設定
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+}
+
+# IAM設定
+resource "google_cloud_run_service_iam_member" "invoker" {
+  count    = var.allow_unauthenticated ? 1 : 0
+  service  = google_cloud_run_v2_service.this.name
+  location = google_cloud_run_v2_service.this.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/terraform/modules/cloud_run_service/outputs.tf
+++ b/terraform/modules/cloud_run_service/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "Cloud Run Service の名前"
+  value       = google_cloud_run_v2_service.this.name
+}
+
+output "service_uri" {
+  description = "Cloud Run Service のURI"
+  value       = google_cloud_run_v2_service.this.uri
+}
+
+output "service_id" {
+  description = "Cloud Run Service のID"
+  value       = google_cloud_run_v2_service.this.id
+}

--- a/terraform/modules/cloud_run_service/variables.tf
+++ b/terraform/modules/cloud_run_service/variables.tf
@@ -1,0 +1,67 @@
+variable "name" {
+  type        = string
+  description = "Cloud Run Service の名前"
+}
+
+variable "region" {
+  type        = string
+  description = "Cloud Run Service をデプロイするリージョン"
+}
+
+variable "env_suffix" {
+  type        = string
+  description = "環境識別子（dev/prod）"
+  default     = "dev"
+}
+
+variable "image_uri" {
+  type        = string
+  description = "コンテナイメージのURI"
+}
+
+variable "service_account" {
+  type        = string
+  description = "Cloud Run Service で使用するサービスアカウント"
+}
+
+variable "vpc_connector" {
+  type        = string
+  description = "VPCコネクタのID"
+  default     = null
+}
+
+variable "allow_unauthenticated" {
+  type        = bool
+  description = "認証なしアクセスを許可するか"
+  default     = false
+}
+
+variable "min_instances" {
+  type        = number
+  description = "最小インスタンス数"
+  default     = 0
+}
+
+variable "max_instances" {
+  type        = number
+  description = "最大インスタンス数"
+  default     = 10
+}
+
+variable "cpu_limit" {
+  type        = string
+  description = "CPU制限"
+  default     = "2"
+}
+
+variable "memory_limit" {
+  type        = string
+  description = "メモリ制限"
+  default     = "4Gi"
+}
+
+variable "env_vars" {
+  description = "コンテナに渡す環境変数 (key → value)"
+  type        = map(string)
+  default     = {} # dev でも prod でも空で良い。呼び出し元で必要分を渡す
+}

--- a/terraform/modules/feature_store/main.tf
+++ b/terraform/modules/feature_store/main.tf
@@ -1,4 +1,4 @@
-# Feature Store の作成
+# Feature Store本体（オンライン/オフライン特徴量の永続化ストレージ）
 resource "google_vertex_ai_featurestore" "main" {
   name    = "${replace(var.project_name, "-", "_")}_featurestore_${var.env_suffix}"
   region  = var.region
@@ -11,6 +11,14 @@ resource "google_vertex_ai_featurestore" "main" {
   }
 
   depends_on = [var.aiplatform_service_dependency]
+
+  # KMS暗号化（prodのみ）
+  dynamic "encryption_spec" {
+    for_each = var.kms_key_name != null ? [1] : []
+    content {
+      kms_key_name = var.kms_key_name
+    }
+  }
 }
 
 # DEX liquidity data の Entity Type

--- a/terraform/modules/feature_store/variables.tf
+++ b/terraform/modules/feature_store/variables.tf
@@ -36,6 +36,12 @@ variable "aiplatform_service_dependency" {
   default     = null
 }
 
+variable "kms_key_name" {
+  description = "Feature Store暗号化用のCloud KMSキー名（prodのみ必須）"
+  type        = string
+  default     = null
+}
+
 variable "basic_features" {
   description = "基本的な特徴量定義（monitoring設定なし）"
   type = map(object({

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,8 +70,13 @@ variable "enable_feature_store" {
   default     = false
 }
 
-# variable "feature_store_node_count" {
-#   type        = number
-#   description = "Feature Store のオンライン配信ノード数"
-#   default     = 1
-# }
+variable "prediction_image_uri" {
+  type        = string
+  description = "予測API用コンテナイメージ"
+  default     = null # 実際のイメージURIを設定
+
+  validation {
+    condition     = var.prediction_image_uri == null || can(regex("^(gcr\\.io|.*-docker\\.pkg\\.dev)/.+", var.prediction_image_uri))
+    error_message = "prediction_image_uri must be a valid container registry URI"
+  }
+}


### PR DESCRIPTION
- import.sh を async 実行に変更し Operation をポーリング
  - インポート前後で entity_count を取得して行数を検証
  - Cloud Run Job タイムアウトを考慮し 9 分で強制終了
- src/features に read_features_batch() を追加
  - gRPC ストリーミングで最大 100 entity/req をサポート
- Terraform
  * cloud_run_service モジュール新設（予測 API 用）
  * prediction_image_uri 変数と dev/prod tfvars 追加
  * fetcher Job/Service に env_suffix パラメータ追加
  * Feature Store に encryption_spec（KMS）を追加
- 既存 env/dev・prod で enable_feature_store=true を既定化
- リファクタリング（変数追加・型チェックなど）