### PR TITLE
mv_looker_latest_status を通常ビュー化し LegacySQL を無効化

### DIFF
--- a/terraform/bootstrap/iam.tf
+++ b/terraform/bootstrap/iam.tf
@@ -61,6 +61,8 @@ resource "google_project_iam_member" "tf_sa_admin_roles" {
     "roles/run.admin",                       # Cloud Run Job 管理
     "roles/cloudscheduler.admin",            # Cloud Scheduler 管理
     "roles/artifactregistry.writer",         # Artifact Registry 書き込み用
+    "roles/cloudfunctions.admin",            # Gen2 関数作成用
+    "roles/eventarc.admin",                  # HTTP トリガの構成用
   ])
   project = var.project_id
   role    = each.value

--- a/terraform/modules/looker_integration/main.tf
+++ b/terraform/modules/looker_integration/main.tf
@@ -53,13 +53,16 @@ resource "google_bigquery_table" "mv_looker_latest_status" {
   table_id   = "mv_looker_latest_status"
   project    = var.project_id
 
-  materialized_view {
+  view {
     query = templatefile("${path.module}/sql/mv_latest_status.sql", {
       project_id       = var.project_id
       dataset_id       = var.dataset_id
       features_dataset = var.features_dataset_id
       features_table   = var.features_table
     })
+
+    # ビューの作成には Legacy SQL を使用しない
+    use_legacy_sql = false
   }
   labels = var.common_labels
 }


### PR DESCRIPTION
* Cloud Functions 権限追加後の 403 を解消するため roles/cloudfunctions.admin 付与
* mv_looker_latest_status を materialized view → view に変更し、use_legacy_sql=false を指定
* MV 固有パラメータ（enable_refresh など）を削除し invalidQuery に対応