### PR TITLE
fix: Cloud Functions Gen2ビルド用のIAM権限を追加

### DIFF
--- a/terraform/bootstrap/iam.tf
+++ b/terraform/bootstrap/iam.tf
@@ -96,6 +96,13 @@ resource "google_service_account_iam_member" "tf_apply_use_vertex_pipeline_sa" {
   member             = "serviceAccount:${google_service_account.tf_apply.email}"
 }
 
+# Cloud Functions のビルド用 SA に impersonate 権限を付与
+resource "google_service_account_iam_member" "tf_apply_actas_compute_sa" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.project_number}-compute@developer.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.tf_apply.email}"
+}
+
 # Cloud Run Jobs の権限付与
 resource "google_project_iam_member" "tf_sa_run_jobs" {
   project = var.project_id


### PR DESCRIPTION
- tf-apply-dev SAにデフォルトCompute SAへのserviceAccountUser権限を付与
- これによりCloud BuildがFunctions Gen2のビルドを実行可能に