### PR TITLE
モデルアーティファクト生成をCIに追加しデプロイ手順を更新

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,8 +20,10 @@ env:
   REGION: asia-northeast1
   PROJECT_ID: ${{ secrets.PROJECT_ID }}
   ENABLE_PREDICTION_GATEWAY: ${{ vars.ENABLE_PREDICTION_GATEWAY || 'false' }}
-  ENV: ${{ github.event.inputs.workspace || 'dev' }}
   ENV_SUFFIX: ${{ github.event.inputs.workspace || 'dev' }}
+  VERSION: v${{ github.run_number }}
+  MODEL_NAME: iforest
+  MODEL_BUCKET: ${{ secrets.PROJECT_ID }}-models
 
 jobs:
   build:
@@ -199,87 +201,64 @@ jobs:
           # outputsを環境変数に保存
           echo "ENDPOINT_ID=$(terraform output -raw vertex_ai_endpoint_id)" >> "$GITHUB_ENV"
 
-      # 13) Model を Vertex AI にデプロイ
-      - name: Upload & Deploy model to Vertex AI
-        id: deploy_vertex
-        if: steps.download_model.outputs.model_found == 'true'
+      # 13) Model をビルド
+      - name: Build model artifact
+        id: build_model
         run: |
           set -euo pipefail
 
-          # ENV_SUFFIXはジョブレベルのenvで定義済みなので、そのまま使用可能
-          MODEL_BUCKET="${PROJECT_ID}-data-${ENV_SUFFIX}"
+          # Python環境セットアップ
+          python3 -m pip install --quiet scikit-learn==1.4.2 joblib==1.4.2 numpy==1.26.4
 
-          # モデルファイルの存在確認
-          if [ -z "$(find models/iforest -type f -name '*.joblib' -o -name '*.pkl' -size +0c 2>/dev/null)" ]; then
-            echo "::error::No valid model files found in models/iforest"
+          # モデルアーティファクト生成
+          echo "Building model artifact version ${VERSION}..."
+          python3 scripts/train_iforest.py \
+            --out vertex_artifact/${VERSION} \
+            --version ${VERSION}
+
+          # 生成確認
+          if [[ ! -f "vertex_artifact/${VERSION}/model.joblib" ]]; then
+            echo "::error::Model artifact generation failed"
             exit 1
           fi
 
-          # GCSへのアップロード
-          echo "Uploading model to gs://${MODEL_BUCKET}/models/iforest/"
-          gsutil cp models/iforest/* gs://${MODEL_BUCKET}/models/iforest/
+          echo "model_generated=true" >> "$GITHUB_OUTPUT"
 
-          # モデルのアップロード（JSON形式で取得）
-          echo "Uploading model to Vertex AI..."
-          MODEL_UPLOAD_OUTPUT=$(gcloud ai models upload \
+      # 14) Model を GCS にアップロード
+      - name: Upload model artifact
+        if: steps.build_model.outputs.model_generated == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # VERSION付きディレクトリをアップロード
+          gsutil -m rsync -r -d vertex_artifact/${VERSION}/ \
+            gs://${MODEL_BUCKET}/${MODEL_NAME}/${VERSION}/
+
+          # latestを更新
+          gsutil -m rsync -r -d vertex_artifact/${VERSION}/ \
+            gs://${MODEL_BUCKET}/${MODEL_NAME}/latest/
+
+      # 15) Model を Vertex AI にデプロイ
+      - name: Upload & Deploy model to Vertex AI
+        id: deploy_vertex
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MODEL_DISPLAY_NAME="iforest-${VERSION}"
+          # --- maintenance: VERSIONディレクトリを指定
+          MODEL_URI="gs://${MODEL_BUCKET}/${MODEL_NAME}/${VERSION}"
+
+          echo "Uploading Vertex Model from ${MODEL_URI}..."
+          MODEL_ID=$(gcloud ai models upload \
             --region="${REGION}" \
-            --display-name="iforest-${ENV_SUFFIX}-$(date +%Y%m%d%H%M%S)" \
-            --artifact-uri="gs://$MODEL_BUCKET/models/iforest/" \
+            --display-name="${MODEL_DISPLAY_NAME}" \
+            --artifact-uri="${MODEL_URI}" \
             --container-image-uri="us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-4:latest" \
-            --format=json)
+            --format="value(name)")
 
-          # jqでmodel fieldを抽出
-          MODEL_RESOURCE_NAME=$(echo "${MODEL_UPLOAD_OUTPUT}" | jq -r '.model')
-
-          # リソース名からモデルIDを抽出
-          MODEL_ID=${MODEL_RESOURCE_NAME##*/}
-
-          if [ -z "$MODEL_ID" ] || [ "$MODEL_ID" = "null" ]; then
-            echo "::error::Failed to get MODEL_ID"
-            echo "::error::Upload output: ${MODEL_UPLOAD_OUTPUT}"
-            exit 1
-          fi
-
-          echo "Model uploaded with ID: ${MODEL_ID}"
-          echo "Full resource name: ${MODEL_RESOURCE_NAME}"
-
-          # 既存のエンドポイントを検索（nameフィルタを使用）
-          ENDPOINT_ID=$(gcloud ai endpoints list \
-            --region="${REGION}" \
-            --filter="name:dex-prediction-endpoint-${ENV_SUFFIX}" \
-            --format='value(name)' || true)
-
-          # エンドポイントが無ければTerraform outputから取得
-          if [ -z "$ENDPOINT_ID" ]; then
-            echo "Existing endpoint not found, getting from Terraform output..."
-            
-            # NOTE: Always point to ./terraform to avoid state lookup failures
-            ENDPOINT_ID=$(terraform -chdir=terraform output -raw vertex_ai_endpoint_id 2>/dev/null || echo "")
-            
-            # それでも空の場合はエラー
-            if [ -z "$ENDPOINT_ID" ]; then
-              echo "::error::ENDPOINT_ID could not be determined from either gcloud list or terraform output"
-              exit 1
-            fi
-          fi
-
-          echo "Using endpoint: ${ENDPOINT_ID}"
-
-          # モデルをエンドポイントにデプロイ
-          gcloud ai endpoints deploy-model "${ENDPOINT_ID}" \
-            --model="${MODEL_ID}" \
-            --display-name="iforest-${ENV_SUFFIX}" \
-            --region="${REGION}" \
-            --traffic-split=0=100 \
-            --machine-type=n1-standard-2
-
-          # GitHub 環境変数へ展開（エンドポイントIDのみ抽出）
-          ENDPOINT_ID_SHORT="${ENDPOINT_ID##*/}"
-          echo "ENDPOINT_ID=${ENDPOINT_ID_SHORT}" >> "$GITHUB_ENV"
-
-          echo "Model deployment completed. Endpoint ID: ${ENDPOINT_ID_SHORT}"
-
-      # 14) トラフィックを切り替えて古いモデルを削除
+      # 16) トラフィックを切り替えて古いモデルを削除
       - name: Swap traffic & abandon old model
         if: steps.deploy_vertex.outcome == 'success'
         run: |
@@ -302,11 +281,11 @@ jobs:
               --region "${REGION}" --quiet
           fi
 
-      # 15) Cloud Functions のデプロイ
+      # 17) Cloud Functions のデプロイ
       - name: Deploy Prediction Gateway Function
         if: env.ENABLE_PREDICTION_GATEWAY == 'true'
         env:
-          ENV_SUFFIX: ${{ env.ENV }}
+          ENV_SUFFIX: ${{ env.ENV_SUFFIX }}
           REGION: ${{ env.REGION }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
         run: |

--- a/scripts/init_model.sh
+++ b/scripts/init_model.sh
@@ -4,146 +4,49 @@ set -euo pipefail
 
 # 設定変数
 MODEL_NAME="iforest"
-MODEL_VERSION="0.0.1-dummy"
-FEATURE_LIST_JSON='["volume_usd","tvl_usd","liquidity","tx_count","vol_rate_24h","tvl_rate_24h","vol_ma_6h","vol_ma_24h","vol_std_24h","vol_tvl_ratio","volume_zscore","hour_of_day","day_of_week"]'
+MODEL_VERSION="${MODEL_VERSION:-v0.0.1}" # SemVer / date tag
+PROJECT_ID="${1:?project id required}"
+ENV_SUFFIX="${2:-dev}"
+MODEL_BUCKET="${PROJECT_ID}-models-${ENV_SUFFIX}"
 
-# 引数チェック
-if [ $# -lt 1 ]; then
-  echo "Usage: $0 <PROJECT_ID> [ENV_SUFFIX]"
-  echo "Example: $0 my-project-id dev"
-  exit 1
-fi
-
-PROJECT_ID=$1
-ENV_SUFFIX=${2:-dev}
-MODEL_BUCKET="${PROJECT_ID}-models"
-MODEL_PATH="${MODEL_NAME}/latest/model.joblib"
-
-echo "Initializing model for project: $PROJECT_ID ($ENV_SUFFIX)"
-echo "Target: gs://${MODEL_BUCKET}/${MODEL_PATH}"
+# スクリプトのディレクトリとリポジトリのルートを取得
+SCRIPT_DIR="$(
+  cd "$(dirname "$0")"
+  pwd
+)"
+REPO_ROOT="$(
+  cd "${SCRIPT_DIR}/.."
+  pwd
+)"
 
 # Python環境の確認
-if ! command -v python3 &>/dev/null; then
-  echo "Error: python3 is required"
-  exit 1
+python3 -m pip install --quiet --root .venv scikit-learn==1.4.2 joblib==1.4.2 numpy==1.26.4
+
+# ローカルアーティファクトのビルド
+OUT_DIR="vertex_artifact/${MODEL_VERSION}"
+python3 "${REPO_ROOT}/scripts/train_iforest.py" --out "$OUT_DIR" --version "$MODEL_VERSION"
+
+echo "Artifact size: $(du -sh $OUT_DIR)"
+
+# 古い latest のバックアップ
+if gsutil -q stat "gs://${MODEL_BUCKET}/${MODEL_NAME}/latest/model/model.joblib"; then
+  BK="gs://${MODEL_BUCKET}/${MODEL_NAME}/legacy/backup_$(date +%Y%m%d_%H%M%S)/"
+  echo "Backup existing model → ${BK}"
+  gsutil -m cp -r "gs://${MODEL_BUCKET}/${MODEL_NAME}/latest/" "$BK"
 fi
 
-# gsutil の確認
-if ! command -v gsutil &>/dev/null; then
-  echo "Error: gsutil is required. Please install Google Cloud SDK"
-  exit 1
-fi
+# 新しいバージョンの同期
+echo "Sync ${MODEL_VERSION} …"
+gsutil -m rsync -r "$OUT_DIR" \
+  "gs://${MODEL_BUCKET}/${MODEL_NAME}/${MODEL_VERSION}/"
 
-# 依存ライブラリをインストール
-echo "Installing required Python packages..."
-python3 -m pip install --quiet --user --only-binary :all: scikit-learn==1.4.2 joblib==1.4.2 numpy==1.26.4
+echo "Promote to latest/ …"
+gsutil -m rsync -r -d "$OUT_DIR" \
+  "gs://${MODEL_BUCKET}/${MODEL_NAME}/latest/"
 
-# PYTHONPATH に .local を追加
-PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-export PYTHONPATH="$HOME/.local/lib/python${PYTHON_VERSION}/site-packages:${PYTHONPATH:-}"
-
-# バケットの存在確認
-echo "Checking if bucket exists..."
-if ! gsutil ls "gs://${MODEL_BUCKET}" &>/dev/null; then
-  echo "Error: Bucket gs://${MODEL_BUCKET} does not exist"
-  echo "Please run Terraform first to create the infrastructure"
-  exit 1
-fi
-
-# 既存モデルの確認
-echo "Checking for existing model..."
-if gsutil -q stat "gs://${MODEL_BUCKET}/${MODEL_PATH}" 2>/dev/null; then
-  echo "Warning: Model already exists at gs://${MODEL_BUCKET}/${MODEL_PATH}"
-  read -p "Do you want to overwrite it? (y/N) " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Aborted"
-    exit 0
-  fi
-fi
-
-# ダミーモデルを作成
-echo "Creating dummy IsolationForest model..."
-python3 <<EOF
-import json
-import joblib
-import numpy as np
-from sklearn.ensemble import IsolationForest
-
-# JSON形式の特徴量リストを読み込み
-FEATURE_LIST = json.loads('''${FEATURE_LIST_JSON}''')
-
-# ダミーデータでモデルを作成
-print(f"Creating model with {len(FEATURE_LIST)} features...")
-print(f"Features: {', '.join(FEATURE_LIST)}")
-
-# より現実的なダミーデータを生成
-np.random.seed(42)
-n_samples = 1000
-X_dummy = np.random.randn(n_samples, len(FEATURE_LIST))
-
-# 一部の特徴量に現実的な範囲を設定
-# volume_usd, tvl_usd, liquidity は正の値
-X_dummy[:, 0:3] = np.abs(X_dummy[:, 0:3]) * 1000000  # USD values
-# tx_count は整数
-X_dummy[:, 3] = np.abs(X_dummy[:, 3].astype(int)) * 100
-# hour_of_day (0-23)
-X_dummy[:, -2] = np.random.randint(0, 24, n_samples)
-# day_of_week (0-6)
-X_dummy[:, -1] = np.random.randint(0, 7, n_samples)
-
-# モデルを訓練
-model = IsolationForest(
-    n_estimators=200,
-    contamination=0.1,
-    random_state=42,
-    n_jobs=-1
-)
-model.fit(X_dummy)
-
-# メタデータを含めて保存（互換性のため辞書形式で保存）
-model_data = {
-    'model': model,
-    'feature_names': FEATURE_LIST,
-    'model_type': 'IsolationForest',
-    'version': '${MODEL_VERSION}',
-    'env': '${ENV_SUFFIX}',
-    'training_samples': n_samples
-}
-
-# 保存
-joblib.dump(model_data, 'dummy_model.joblib')
-print("Dummy model created successfully")
-
-# スコアサンプルの表示
-sample_scores = model.score_samples(X_dummy[:10])
-print(f"Sample anomaly scores: mean={sample_scores.mean():.4f}, std={sample_scores.std():.4f}")
-print(f"Model file saved: dummy_model.joblib")
-EOF
-
-# Python実行の確認
-if [ $? -ne 0 ]; then
-  echo "Error: Failed to create dummy model"
-  exit 1
-fi
-
-# ファイルサイズ確認
-echo "Model file size: $(ls -lh dummy_model.joblib | awk '{print $5}')"
-
-# GCS にアップロード
-echo "Uploading model to GCS..."
-if gsutil cp dummy_model.joblib "gs://${MODEL_BUCKET}/${MODEL_PATH}"; then
-  echo "Model successfully uploaded to gs://${MODEL_BUCKET}/${MODEL_PATH}"
-
-  # アップロード確認
-  echo "Verifying upload..."
-  gsutil ls -l "gs://${MODEL_BUCKET}/${MODEL_NAME}/latest/"
-else
-  echo "Failed to upload model"
-  exit 1
-fi
+echo "GCS layout:"
+gsutil ls -r "gs://${MODEL_BUCKET}/${MODEL_NAME}/${MODEL_VERSION}/"
 
 # クリーンアップ
-rm -f dummy_model.joblib
-echo "Cleanup completed"
-echo "Model initialization completed!"
+rm -rf vertex_artifact
+echo "Model initialization completed"

--- a/scripts/train_iforest.py
+++ b/scripts/train_iforest.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import joblib
+import numpy as np
+from sklearn.ensemble import IsolationForest
+
+FEATURES = [
+    "volume_usd",
+    "tvl_usd",
+    "liquidity",
+    "tx_count",
+    "vol_rate_24h",
+    "tvl_rate_24h",
+    "vol_ma_6h",
+    "vol_ma_24h",
+    "vol_std_24h",
+    "vol_tvl_ratio",
+    "volume_zscore",
+    "hour_of_day",
+    "day_of_week",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def main(out_dir: Path, version: str):
+    """モデルを生成します。"""
+    logger.info(f"Generate model → {out_dir}")
+    n, d = 1000, len(FEATURES)
+    X = np.random.randn(n, d)
+    X[:, 0:3] = np.abs(X[:, 0:3]) * 1_000_000
+    X[:, 3] = np.abs(X[:, 3]).astype(int) * 100
+    X[:, -2] = np.random.randint(0, 24, n)
+    X[:, -1] = np.random.randint(0, 7, n)
+
+    model = IsolationForest(n_estimators=200, contamination=0.1, random_state=42)
+    model.fit(X)
+
+    model_path = out_dir / "model.joblib"
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, model_path)
+
+    meta = {"feature_names": FEATURES, "model_type": "IsolationForest", "version": version, "training_samples": n}
+    schema = out_dir / "schema"
+    schema.mkdir(exist_ok=True)
+    (schema / "metadata.json").write_text(json.dumps(meta, indent=2))
+    logger.info("Artifact ready")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", required=True, help="output root dir")
+    p.add_argument("--version", required=True)
+    args = p.parse_args()
+    main(Path(args.out), args.version)


### PR DESCRIPTION
* build-and-deploy.yml に VERSION 付きモデルビルド・アップロード・デプロイの新ステップを追加
* env 変数 MODEL\_BUCKET, VERSION などを統一
* scripts/init\_model.sh を Vertex 互換アーティファクト生成フローへ置換しバックアップ処理を追加
* scripts/train\_iforest.py を新規作成し IsolationForest ダミーモデルを生成
* モデルファイル配置を root の model.joblib に統一、GCS パスも VERSION ディレクトリ基準へ変更
* 旧 latest ディレクトリ退避と traffic 切替ロジックを整理